### PR TITLE
Misspelling in example

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -54,7 +54,7 @@ function getExampleJs () {
   try {
     return fs.readFileSync(path.join(__dirname, 'example.js'))
   } catch (e) {
-    return "var $$$rePo = require('$$$REPO')\n\nconsole.log('hello warld')"
+    return "var $$$rePo = require('$$$REPO')\n\nconsole.log('hello world')"
   }
 }
 

--- a/template.md
+++ b/template.md
@@ -13,7 +13,7 @@ $$EXAMPLE
 outputs
 
 ```
-hello warld
+hello world
 ```
 
 ## API


### PR DESCRIPTION
You wrote `hello warld` instead of `hello world`. Quick fix :)